### PR TITLE
Add maven.compiler.release property to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
 		<project.reporting.outputEncoding>${project.encoding}</project.reporting.outputEncoding>
 		<jdk.version>21</jdk.version>
 		<jdk.full.version>JavaSE-${jdk.version}</jdk.full.version>
+		<maven.compiler.release>${jdk.version}</maven.compiler.release>
 		<maven.compiler.source>${jdk.version}</maven.compiler.source>
 		<maven.compiler.target>${jdk.version}</maven.compiler.target>
 		<maven.compiler.fork>true</maven.compiler.fork>


### PR DESCRIPTION
Fixes the following build error:

`Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.13.0:compile (default-compile) on project civitas.base: Compilation failure: Compilation failure: [ERROR] not setting the location of system modules may lead to class files that cannot run on JDK 21`